### PR TITLE
refactoring: update http module to http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,10 @@ Inject it to your class (could be Component, Service, etc...)
 
 - `fetch-user.command.ts`:  
   ```ts
-  import {RequestMethod} from '@angular/http';
-  import {ApiBaseCommand, UrlPathParameters} from 'ng2-api-client';
+  import {ApiBaseCommand, RequestMethod, UrlPathParameters} from 'ng2-api-client';
   
   export class FetchUserCommand implements ApiBaseCommand {
-    public headers: Headers = new Headers({'X-Forwarded-For': 'proxy1'});
+    public headers: Headers = {'X-Forwarded-For': 'proxy1'};
     public method: RequestMethod = RequestMethod.Get;
     public url: string = '/api/user/:uuid';
     public urlPathParameters: UrlPathParameters;
@@ -81,7 +80,7 @@ of required retries and the ApiClient will take care of it.
 
 - __method__
 
-  The property method defines the HTTP method. It requires the enum value of `RequestMethod` from `@angular/http`.
+  The property method defines the HTTP method. It requires the string enum value of `RequestMethod`.
 
 - __url__
 
@@ -97,9 +96,9 @@ of required retries and the ApiClient will take care of it.
 
 - __urlPathParameters__
 
-  This is required when the wildcard is included in the url.
+  This value is required when the wildcard is included in the url.
   
-  Example: `{role: 'admin'}` with the url: `/user/:role` will generate: `/user/role`
+  Example: `{role: 'admin'}` with the url: `/user/:role` will generate: `/user/admin`
 
 - __queryParameters__
 
@@ -111,7 +110,7 @@ of required retries and the ApiClient will take care of it.
 
 - __headers__
 
-  You can provide headers with the usage of `Headers` object from `@angular/http`.
+  Used to set the headers of your request.
 
 - __body__
 
@@ -121,6 +120,21 @@ of required retries and the ApiClient will take care of it.
 
   Boolean value that indicates whether or not requests should be made using credentials
   such as cookies, authorization headers or TLS client certificates.
+  
+  Default value: `false`.
+
+- __responseType__
+
+  Used to set the response type of your request. Can be one of:
+  `'arraybuffer' | 'blob' | 'json' | 'text'`.
+  
+  Default value: `json`.
+
+- __reportProgress__
+
+  Boolean value that indicates whether or not requests should report about progress.
+  
+  Default value: `false`.
 
 ## Testing
 Run `npm test` to execute tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4346,9 +4346,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz",
-      "integrity": "sha1-YGAiUIR5tV/6NotY/uljoD39eww=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": ">=4.0.0",
-    "@angular/http": ">=4.0.0",
-    "rxjs": ">=5.1.0"
+    "@angular/core": ">=4.3.0",
+    "@angular/common": ">=4.3.0",
+    "rxjs": ">=5.1.0",
+    "typscript": ">=2.4.1"
   },
   "devDependencies": {
     "@angular/common": "~4.3.2",
@@ -64,7 +65,7 @@
     "ts-loader": "~2.3.2",
     "tslint": "~4.4.2",
     "tslint-eslint-rules": "~3.2.3",
-    "typescript": "~2.2.1",
+    "typescript": "~2.5.2",
     "uglify-js": "~3.0.27",
     "webpack": "~1.13.3",
     "zone.js": "~0.8.16"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,14 +9,17 @@ export default {
   moduleName: 'api.client',
   external: [
       '@angular/core',
-      '@angular/http',
-      'rxjs/add/operator/map',
+      '@angular/common/http',
+      'rxjs/add/observable/of',
+      'rxjs/add/observable/throw',
+      'rxjs/add/operator/delay',
       'rxjs/add/operator/catch',
+      'rxjs/add/operator/switchMap',
       'rxjs/Observable',
   ],
   globals: {
     '@angular/core': 'ng.core',
-    '@angular/http': 'ng.http',
+    '@angular/common/http': 'ng.common.http',
     'rxjs/Observable': 'rxjx.observable',
   },
   plugins: [typescript({typescript: require('typescript')})]

--- a/src/apiBaseCommand.ts
+++ b/src/apiBaseCommand.ts
@@ -1,4 +1,6 @@
-import {RequestMethod, Headers} from '@angular/http';
+export interface RequestHeaders {
+    [key: string]: string | string[];
+}
 
 export interface QueryParameters {
     [key: string]: string | number;
@@ -8,14 +10,27 @@ export interface UrlPathParameters {
     [key: string]: string | number;
 }
 
+export enum RequestMethod {
+    Delete = 'DELETE',
+    Get = 'GET',
+    Head = 'HEAD',
+    Jsonp = 'JSONP',
+    Options = 'OPTIONS',
+    Patch = 'PATCH',
+    Post = 'POST',
+    Put = 'PUT',
+}
+
 export interface ApiBaseCommand {
     method: RequestMethod;
     url: string;
 
     // optional
     body?: any;
-    headers?: Headers;
+    headers?: RequestHeaders;
     queryParameters?: QueryParameters;
+    responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
+    reportProgress?: boolean;
     urlPathParameters?: UrlPathParameters;
     withCredentials?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import {NgModule} from '@angular/core';
 import {ApiClient} from './apiClient';
 import {UrlBuilder} from './url.builder';
+import {HttpClientModule} from '@angular/common/http';
 
 export * from './apiBaseCommand';
 export * from './apiClient';
 
 @NgModule({
+    imports: [HttpClientModule],
     providers: [ApiClient, UrlBuilder]
 })
 export class ApiClientModule {}

--- a/test/url.builder.spec.ts
+++ b/test/url.builder.spec.ts
@@ -24,7 +24,7 @@ describe('Url builder', () => {
     });
 
     it('should throw an error', () => {
-        const init = () => builder.build(
+        const init: () => string = (): string => builder.build(
             '/endpoint/:name',
             {
                 id: 4,


### PR DESCRIPTION
**Breaking changes**
- Uses new Http client.
- Headers are now key=>value and built by api client.
- Typescript 2.4.1 or higher required.
- @angular/common 2.3.0 or higher required.

Closes #7