### PR TITLE
Feature/do not depend on http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,21 @@ npm install --save ng2-api-client
 Import __API client module__ to your `app.module.ts`
 ```ts
 // ...
-import {ApiClientModule} from 'ng2-api-client';
+import {HttpClient, HttpClientModule} from '@angular/common/http';
+import {ApiClientHttpClient, ApiClientModule} from 'ng2-api-client';
+import {HttpClient} from 'ng2-api-client';
 // ...
 
 @NgModule({
   declarations: [AppComponent],
   imports: [
     // ...
-    ApiClientModule,
+    HttpClientModule,
+    // ...
+    ApiClientModule.forRoot({httpClient: {
+        provide: ApiClientHttpClient,
+        useClass: HttpClient,
+    }}),
   ],
   bootstrap: [AppComponent]
 })
@@ -31,7 +38,7 @@ export class AppModule {}
 ```
 
 Inject it to your class (could be Component, Service, etc...)
-- `app.component.ts`:  
+- `app.component.ts`:
   ```ts
   import {Component, OnInit} from '@angular/core';
   import {ApiClient} from 'ng2-api-client';
@@ -41,8 +48,8 @@ Inject it to your class (could be Component, Service, etc...)
     templateUrl: './app.component.html',
   })
   export class AppComponent implements OnInit {
-    constructor(private apiClient: ApiClient) {}
-    
+    constructor(private readonly apiClient: ApiClient) {}
+
     ngOnInit() {
       this.apiClient
         .executeRequest<User>(new FetchUserCommand('u-u-i-d'))
@@ -53,10 +60,10 @@ Inject it to your class (could be Component, Service, etc...)
   }
   ```
 
-- `fetch-user.command.ts`:  
+- `fetch-user.command.ts`:
   ```ts
   import {ApiBaseCommand, RequestMethod, UrlPathParameters} from 'ng2-api-client';
-  
+
   export class FetchUserCommand implements ApiBaseCommand {
     public headers: Headers = {'X-Forwarded-For': 'proxy1'};
     public method: RequestMethod = RequestMethod.Get;
@@ -85,9 +92,9 @@ of required retries and the ApiClient will take care of it.
 - __url__
 
   The url path without a scheme. Url can include wildcards starting with `:`.
-  
+
   Examples: `/api/user/:id` or `/api/user/:name/:lastname` ...
-  
+
   If the url includes the wildcard it will be validated with an input defined in the property
   `urlPathParameters` and replaced by the provided value.
 
@@ -97,15 +104,15 @@ of required retries and the ApiClient will take care of it.
 - __urlPathParameters__
 
   This value is required when the wildcard is included in the url.
-  
+
   Example: `{role: 'admin'}` with the url: `/user/:role` will generate: `/user/admin`
 
 - __queryParameters__
 
   An object defining query parameters.
-  
+
   _Examples:_
-  
+
    `{search: 'neymar', team: 'psg'}` will generate: `?search=neymar&team=psg`
 
 - __headers__
@@ -120,20 +127,20 @@ of required retries and the ApiClient will take care of it.
 
   Boolean value that indicates whether or not requests should be made using credentials
   such as cookies, authorization headers or TLS client certificates.
-  
+
   Default value: `false`.
 
 - __responseType__
 
   Used to set the response type of your request. Can be one of:
   `'arraybuffer' | 'blob' | 'json' | 'text'`.
-  
+
   Default value: `json`.
 
 - __reportProgress__
 
   Boolean value that indicates whether or not requests should report about progress.
-  
+
   Default value: `false`.
 
 ## Testing
@@ -145,8 +152,8 @@ The MIT License (see the [LICENSE](LICENSE.md) file for the full text)
 ## Publishing
 Always run `npm run build` before.
 
-To publish a package run: `npm publish ./dist/ng2-api-client`
+To publish a package run: `npm publish ./dist/lib`
 
 If you want only to run it locally use `npm pack` as follows:
-1. `npm pack ./dist/ng2-api-client`
+1. `npm pack ./dist/lib`
 2. In your project `npm i ../PATH_TO_TAR/ng2-api-client-X.X.X.tgz` where X.X.X is the current version of a library.

--- a/projects/ng2-api-client/src/lib/api-client.module.ts
+++ b/projects/ng2-api-client/src/lib/api-client.module.ts
@@ -8,17 +8,15 @@ export interface ApiClientModuleConfig {
 
 @NgModule()
 export class ApiClientModule {
-    /**
-     * Use this method in your root module to provide the ApiClient
-     */
-    static forRoot (config: ApiClientModuleConfig): ModuleWithProviders<ApiClientModule> {
+    // Use this method in your root module to provide the ApiClient
+    public static forRoot (config: ApiClientModuleConfig): ModuleWithProviders<ApiClientModule> {
         return {
             ngModule: ApiClientModule,
             providers: [
                 config.httpClient,
                 ApiClient,
                 UrlBuilder,
-            ]
+            ],
         };
     }
 }

--- a/projects/ng2-api-client/src/lib/api-client.module.ts
+++ b/projects/ng2-api-client/src/lib/api-client.module.ts
@@ -1,10 +1,24 @@
-import {HttpClientModule} from '@angular/common/http';
-import {NgModule} from '@angular/core';
+import {ModuleWithProviders, NgModule, Provider} from '@angular/core';
 import {ApiClient} from './api.client';
 import {UrlBuilder} from './url.builder';
 
-@NgModule({
-    imports: [HttpClientModule],
-    providers: [ApiClient, UrlBuilder],
-})
-export class ApiClientModule { }
+export interface ApiClientModuleConfig {
+    httpClient: Provider;
+}
+
+@NgModule()
+export class ApiClientModule {
+    /**
+     * Use this method in your root module to provide the ApiClient
+     */
+    static forRoot (config: ApiClientModuleConfig): ModuleWithProviders<ApiClientModule> {
+        return {
+            ngModule: ApiClientModule,
+            providers: [
+                config.httpClient,
+                ApiClient,
+                UrlBuilder,
+            ]
+        };
+    }
+}

--- a/projects/ng2-api-client/src/lib/api.client.spec.ts
+++ b/projects/ng2-api-client/src/lib/api.client.spec.ts
@@ -1,8 +1,10 @@
+import {HttpClient} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from '@angular/common/http/testing';
 import {TestBed} from '@angular/core/testing';
 import {ApiBaseCommand, QueryParameters, RequestHeaders, RequestMethod, UrlPathParameters} from './api-base.command';
+import {ApiClientModule} from './api-client.module';
 import {ApiClient} from './api.client';
-import {UrlBuilder} from './url.builder';
+import {ApiClientHttpClient} from './http';
 
 /* tslint:disable:max-classes-per-file */
 class GetCommand implements ApiBaseCommand {
@@ -51,10 +53,14 @@ class PostCommand implements ApiBaseCommand {
 describe('Api Client Service', (): void => {
     beforeEach((): void => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [
-                ApiClient,
-                UrlBuilder,
+            imports: [
+                HttpClientTestingModule,
+                ApiClientModule.forRoot({
+                    httpClient: {
+                        provide: ApiClientHttpClient,
+                        useClass: HttpClient,
+                    },
+                }),
             ],
         });
     });

--- a/projects/ng2-api-client/src/lib/api.client.ts
+++ b/projects/ng2-api-client/src/lib/api.client.ts
@@ -1,8 +1,9 @@
-import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
+import {HttpHeaders, HttpParams} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable, ObservableInput, of, throwError} from 'rxjs';
 import {catchError, delay, switchMap} from 'rxjs/operators';
 import {ApiBaseCommand, QueryParameters, RequestHeaders} from './api-base.command';
+import {ApiClientHttpClient} from './http';
 import {UrlBuilder} from './url.builder';
 
 @Injectable()
@@ -10,7 +11,7 @@ export class ApiClient {
     private defaultRetryDelay: number | Date = 0;
 
     constructor (
-        private readonly httpClient: HttpClient,
+        private readonly httpClient: ApiClientHttpClient,
         private readonly urlBuilder: UrlBuilder,
     ) {}
 

--- a/projects/ng2-api-client/src/lib/http.ts
+++ b/projects/ng2-api-client/src/lib/http.ts
@@ -1,3 +1,3 @@
-import {HttpClient} from "@angular/common/http";
+import {HttpClient} from '@angular/common/http';
 
 export abstract class ApiClientHttpClient extends HttpClient {}

--- a/projects/ng2-api-client/src/lib/http.ts
+++ b/projects/ng2-api-client/src/lib/http.ts
@@ -1,0 +1,3 @@
+import {HttpClient} from "@angular/common/http";
+
+export abstract class ApiClientHttpClient extends HttpClient {}

--- a/projects/ng2-api-client/src/public_api.ts
+++ b/projects/ng2-api-client/src/public_api.ts
@@ -5,3 +5,4 @@
 export * from './lib/api.client';
 export * from './lib/api-base.command';
 export * from './lib/api-client.module';
+export * from './lib/http';


### PR DESCRIPTION
BC: This is changing the usage of the ApiClientModule to inject the Http Client from the host application.

The new way of importing the modules should be as follows:

```ts
ApiClientModule.forRoot({httpClient: {
    provide: ApiClientHttpClient,
    useClass: HttpClient,
}})
```

You can import the `ApiClientModule` in the `AppModule` only, that should be enough.